### PR TITLE
Fix lower/upper case extensions on Linux

### DIFF
--- a/lyrico/config.py
+++ b/lyrico/config.py
@@ -67,7 +67,7 @@ class Config():
 	# This means that for 'wma' in this list, files with '.wma' and '.WMA' extensions 
 	# will be added to the list.
 
-	audio_formats = ['mp3', 'flac', 'm4a', 'mp4', 'OGG', 'wma']
+	audio_formats = ['[Mm][Pp]3', '[Ff][Ll][Aa][Cc]', '[Mm]4[Aa]', '[Mm][Pp]4', '[Oo][Gg][Gg]', '[Oo][Gg][Aa]', '[Ww][Mm][Aa]']
 
 	lyrics_dir = None
 	source_dir = None

--- a/lyrico/song.py
+++ b/lyrico/song.py
@@ -186,10 +186,10 @@ class Song():
 				# Both flac and OGG(Vorbis & FLAC), are being read/write as Vorbis Comments.
 				# Vorbis Comments don't have a standard 'lyrics' tag. The 'LYRICS' tag is 
 				# most common non-standard tag used for lyrics.
-				if self.format == 'flac' or self.format == 'OGG':
+				if self.format == 'flac' or self.format == 'ogg' or self.format == 'oga':
 					self.tag[lyrics_key] = self.lyrics
 
-				if self.format == 'wma' or self.format == 'WMA':
+				if self.format == 'wma':
 					# ASF Format uses ASFUnicodeAttribute objects instead of Python's Unicode
 					self.tag[lyrics_key] = ASFUnicodeAttribute(self.lyrics)
 

--- a/lyrico/song_helper.py
+++ b/lyrico/song_helper.py
@@ -178,7 +178,7 @@ def get_song_data(path):
 	error = None
 
 	# format will the part of string after last '.' character
-	song_format = path[ path.rfind('.') + 1 : ]
+	song_format = path[ path.rfind('.') + 1 : ].lower
 
 
 	try:


### PR DESCRIPTION
On Linux original code can't detect Vorbis files with extensions in lower case. Don't know how it works on Windows. So here is the fix.
